### PR TITLE
Add Axum server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ axum = "0.6.11"
 prometheus-client = "0.19.0"
 sysinfo = "0.28.0"
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
+tower = "0.4.13"
+tower-http = { version = "0.4.0", features = ["trace"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+axum = "0.6.11"
+prometheus-client = "0.19.0"
 sysinfo = "0.28.0"
+tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{cmp};
+use std::cmp;
 use sysinfo::{ComponentExt, PidExt, ProcessExt, System, SystemExt};
 
 /// Structure containing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::cmp;
+use std::{cmp, collections::HashMap};
 use sysinfo::{ComponentExt, PidExt, ProcessExt, System, SystemExt};
 
 /// Structure containing
@@ -20,13 +20,11 @@ pub fn cpu_usage() -> f32 {
 }
 
 /// Returns the CPU package temperature.
-pub fn cpu_temperature(sys: &System) -> f32 {
-	for com in sys.components() {
-		let temp = com.temperature();
-		println!("{}, {}:", com.label(), temp);
-	}
-
-	0.
+pub fn cpu_temperature(sys: &System) -> Vec<(&str, f32)> {
+	sys.components()
+		.iter()
+		.map(|component| (component.label(), component.temperature()))
+		.collect()
 }
 
 /// Returns a vector of `ProcessStruct` containing the information of no more than n processes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{cmp, collections::HashMap};
+use std::{cmp};
 use sysinfo::{ComponentExt, PidExt, ProcessExt, System, SystemExt};
 
 /// Structure containing

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,13 @@ use tracing::Level;
 
 #[tokio::main]
 async fn main() {
+    // Add HTTP tracing to the Info level for HTTP requests.
 	tracing_subscriber::fmt()
 		.with_target(false)
 		.with_max_level(Level::INFO)
 		.compact()
 		.init();
-	// build our application with a route
+
 	let app = Router::new().route("/metrics", get(get_metrics)).layer(
 		ServiceBuilder::new().layer(
 			TraceLayer::new_for_http()
@@ -28,8 +29,6 @@ async fn main() {
 		),
 	);
 
-	// run our app with hyper
-	// `axum::Server` is a re-export of `hyper::Server`
 	let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 	tracing::info!("Listening on {addr}");
 	axum::Server::bind(&addr)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,44 +1,32 @@
-use std::{thread, time::Duration, sync::atomic::AtomicU64, net::SocketAddr};
+use std::{sync::atomic::AtomicU64, net::SocketAddr};
 
 use axum::{Router, routing::get};
 use prometheus_client::{registry::Registry, metrics::{family::Family, gauge::Gauge}, encoding::{EncodeLabelSet, text::encode}};
 use sysinfo::{System, SystemExt};
-use system_scraper::{cpu_temperature, top_processes, ProcessInfo};
-
-// fn main() {
-// 	let mut sys = System::new_all();
-
-// 	let mut processes: Vec<ProcessInfo>;
-
-// 	loop {
-// 		sys.refresh_all();
-
-// 		// dbg!(cpu_usage());
-// 		dbg!(sys.load_average());
-// 		cpu_temperature(&sys);
-// 		processes = top_processes(&sys, 5);
-
-// 		for process in processes.iter() {
-// 			println!(
-// 				"Process {} ({}): {}",
-// 				process.name, process.pid, process.cpu_usage
-// 			);
-// 		}
-// 		println!();
-
-// 		thread::sleep(Duration::from_millis(2000));
-// 	}
-// }
+use tower::{ServiceBuilder};
+use tower_http::trace::{TraceLayer, self};
+use system_scraper::{cpu_temperature};
+use tracing::Level;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+    .with_target(false)
+    .with_max_level(Level::INFO)
+    .compact()
+    .init();
     // build our application with a route
     let app = Router::new()
-        .route("/metrics", get(get_metrics));
+        .route("/metrics", get(get_metrics))
+        .layer(ServiceBuilder::new()
+        .layer(TraceLayer::new_for_http()
+            .make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
+            .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),));
 
     // run our app with hyper
     // `axum::Server` is a re-export of `hyper::Server`
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    tracing::info!("Listening on {addr}");
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
@@ -59,7 +47,7 @@ async fn get_metrics() -> String {
     for (label, temp) in temps {
         cpu_temperatures.get_or_create(&CPUTempLabels { core: label.to_string() }).set(temp.into());
     }
-    registry.register("cpu_temperature", "The temperature for each CPU core", cpu_temperatures.clone());
+    registry.register("cpu_temperature", "The temperature for each CPU core", cpu_temperatures);
     let mut buffer = String::new();
     encode(&mut buffer, &registry).expect("Should not have died here!");
     buffer

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,66 @@
-use std::{thread, time::Duration};
+use std::{thread, time::Duration, sync::atomic::AtomicU64, net::SocketAddr};
 
+use axum::{Router, routing::get};
+use prometheus_client::{registry::Registry, metrics::{family::Family, gauge::Gauge}, encoding::{EncodeLabelSet, text::encode}};
 use sysinfo::{System, SystemExt};
 use system_scraper::{cpu_temperature, top_processes, ProcessInfo};
 
-fn main() {
-	let mut sys = System::new_all();
+// fn main() {
+// 	let mut sys = System::new_all();
 
-	let mut processes: Vec<ProcessInfo>;
+// 	let mut processes: Vec<ProcessInfo>;
 
-	loop {
-		sys.refresh_all();
+// 	loop {
+// 		sys.refresh_all();
 
-		// dbg!(cpu_usage());
-		dbg!(sys.load_average());
-		cpu_temperature(&sys);
-		processes = top_processes(&sys, 5);
+// 		// dbg!(cpu_usage());
+// 		dbg!(sys.load_average());
+// 		cpu_temperature(&sys);
+// 		processes = top_processes(&sys, 5);
 
-		for process in processes.iter() {
-			println!(
-				"Process {} ({}): {}",
-				process.name, process.pid, process.cpu_usage
-			);
-		}
-		println!();
+// 		for process in processes.iter() {
+// 			println!(
+// 				"Process {} ({}): {}",
+// 				process.name, process.pid, process.cpu_usage
+// 			);
+// 		}
+// 		println!();
 
-		thread::sleep(Duration::from_millis(2000));
-	}
+// 		thread::sleep(Duration::from_millis(2000));
+// 	}
+// }
+
+#[tokio::main]
+async fn main() {
+    // build our application with a route
+    let app = Router::new()
+        .route("/metrics", get(get_metrics));
+
+    // run our app with hyper
+    // `axum::Server` is a re-export of `hyper::Server`
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct CPUTempLabels {
+    core: String,
+}
+
+async fn get_metrics() -> String {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+    let mut registry = Registry::default();
+    let cpu_temperatures = Family::<CPUTempLabels, Gauge<f64, AtomicU64>>::default();
+    let temps = cpu_temperature(&sys);
+    for (label, temp) in temps {
+        cpu_temperatures.get_or_create(&CPUTempLabels { core: label.to_string() }).set(temp.into());
+    }
+    registry.register("cpu_temperature", "The temperature for each CPU core", cpu_temperatures.clone());
+    let mut buffer = String::new();
+    encode(&mut buffer, &registry).expect("Should not have died here!");
+    buffer
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,6 @@ async fn get_metrics() -> String {
 		cpu_temperatures,
 	);
 	let mut buffer = String::new();
-	encode(&mut buffer, &registry).expect("Could not encode registry's metrics");
+	encode(&mut buffer, &registry).expect("could not encode registry's metrics");
 	buffer
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
 		),
 	);
 
-	let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+	let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
 	tracing::info!("Listening on {addr}");
 	axum::Server::bind(&addr)
 		.serve(app.into_make_service())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,54 +1,67 @@
-use std::{sync::atomic::AtomicU64, net::SocketAddr};
+use std::{net::SocketAddr, sync::atomic::AtomicU64};
 
-use axum::{Router, routing::get};
-use prometheus_client::{registry::Registry, metrics::{family::Family, gauge::Gauge}, encoding::{EncodeLabelSet, text::encode}};
+use axum::{routing::get, Router};
+use prometheus_client::{
+	encoding::{text::encode, EncodeLabelSet},
+	metrics::{family::Family, gauge::Gauge},
+	registry::Registry,
+};
 use sysinfo::{System, SystemExt};
-use tower::{ServiceBuilder};
-use tower_http::trace::{TraceLayer, self};
-use system_scraper::{cpu_temperature};
+use system_scraper::cpu_temperature;
+use tower::ServiceBuilder;
+use tower_http::trace::{self, TraceLayer};
 use tracing::Level;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-    .with_target(false)
-    .with_max_level(Level::INFO)
-    .compact()
-    .init();
-    // build our application with a route
-    let app = Router::new()
-        .route("/metrics", get(get_metrics))
-        .layer(ServiceBuilder::new()
-        .layer(TraceLayer::new_for_http()
-            .make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
-            .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),));
+	tracing_subscriber::fmt()
+		.with_target(false)
+		.with_max_level(Level::INFO)
+		.compact()
+		.init();
+	// build our application with a route
+	let app = Router::new().route("/metrics", get(get_metrics)).layer(
+		ServiceBuilder::new().layer(
+			TraceLayer::new_for_http()
+				.make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
+				.on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
+		),
+	);
 
-    // run our app with hyper
-    // `axum::Server` is a re-export of `hyper::Server`
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    tracing::info!("Listening on {addr}");
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+	// run our app with hyper
+	// `axum::Server` is a re-export of `hyper::Server`
+	let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+	tracing::info!("Listening on {addr}");
+	axum::Server::bind(&addr)
+		.serve(app.into_make_service())
+		.await
+		.unwrap();
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct CPUTempLabels {
-    core: String,
+	core: String,
 }
 
 async fn get_metrics() -> String {
-    let mut sys = System::new_all();
-    sys.refresh_all();
-    let mut registry = Registry::default();
-    let cpu_temperatures = Family::<CPUTempLabels, Gauge<f64, AtomicU64>>::default();
-    let temps = cpu_temperature(&sys);
-    for (label, temp) in temps {
-        cpu_temperatures.get_or_create(&CPUTempLabels { core: label.to_string() }).set(temp.into());
-    }
-    registry.register("cpu_temperature", "The temperature for each CPU core", cpu_temperatures);
-    let mut buffer = String::new();
-    encode(&mut buffer, &registry).expect("Should not have died here!");
-    buffer
+	let mut sys = System::new_all();
+	sys.refresh_all();
+	let mut registry = Registry::default();
+	let cpu_temperatures = Family::<CPUTempLabels, Gauge<f64, AtomicU64>>::default();
+	let temps = cpu_temperature(&sys);
+	for (label, temp) in temps {
+		cpu_temperatures
+			.get_or_create(&CPUTempLabels {
+				core: label.to_string(),
+			})
+			.set(temp.into());
+	}
+	registry.register(
+		"cpu_temperature",
+		"The temperature for each CPU core",
+		cpu_temperatures,
+	);
+	let mut buffer = String::new();
+	encode(&mut buffer, &registry).expect("Should not have died here!");
+	buffer
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,6 @@ async fn get_metrics() -> String {
 		cpu_temperatures,
 	);
 	let mut buffer = String::new();
-	encode(&mut buffer, &registry).expect("Should not have died here!");
+	encode(&mut buffer, &registry).expect("Could not encode registry's metrics");
 	buffer
 }


### PR DESCRIPTION
We are finally serving Prometheus metrics.

We will bind all other metrics we track (non-string based) to this server from now on.